### PR TITLE
fix: accept article param in get_provision for fleet audit compatibility

### DIFF
--- a/src/tools/get-provision.ts
+++ b/src/tools/get-provision.ts
@@ -14,6 +14,7 @@ export interface GetProvisionInput {
   chapter?: string;
   section?: string;
   provision_ref?: string;
+  article?: string;
 }
 
 export interface ProvisionResult {
@@ -48,7 +49,7 @@ export async function getProvision(
 
   const resolvedDocumentId = resolveExistingStatuteId(db, input.document_id) ?? input.document_id;
 
-  const provisionRef = input.provision_ref ?? input.section;
+  const provisionRef = input.provision_ref ?? input.section ?? input.article;
 
   // If no specific provision, return all provisions for the document (capped)
   const MAX_PROVISIONS = 200;

--- a/src/utils/statute-id.ts
+++ b/src/utils/statute-id.ts
@@ -116,6 +116,7 @@ export function resolveDocumentId(
   db: Db,
   input: string,
 ): string | null {
+  if (!input || typeof input !== 'string') return null;
   const trimmed = input.trim();
   if (!trimmed) return null;
 


### PR DESCRIPTION
## Summary

- Adds `article?: string` to `GetProvisionInput` interface in `src/tools/get-provision.ts`
- Updates provision reference resolution to `input.provision_ref ?? input.section ?? input.article`
- Adds null guard to `resolveDocumentId` in `src/utils/statute-id.ts` before calling `input.trim()`

## Problem

The fleet audit test sends `{"document_id": "...", "article": "1"}` but the tool only accepted `section` and `provision_ref`. The `article` field was silently ignored, causing the tool to return all provisions instead of the specific one requested.

## Test plan

- [x] `npm run lint` passes
- [x] No new test failures introduced
- [x] Verified on dev branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)