### PR TITLE
chore(gitignore): ignore data/*.tmp + remove stale database.db.tmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ data/*.db
 data/*.db-journal
 data/*.db-wal
 data/*.db-shm
+data/*.tmp
 data/seed/
 data/source/
 .env


### PR DESCRIPTION
## Summary

\`data/database.db.tmp\` was committed as a 0-byte file at some point (commit 094c153) and has been an inert tracked artifact ever since. The pretest hook added in #129 (\`bash scripts/download-db.sh\`) uses this exact path as its gunzip intermediate, so every fresh test run deletes the file → working tree shows \`D data/database.db.tmp\` → \`apply-mcp-standard.py\` pre-flight fails on dirty tree.

## Diff

2 changes, +1 line, -1 file (0 bytes):

1. Add \`data/*.tmp\` to \`.gitignore\` (covers any future .tmp variants)
2. \`git rm data/database.db.tmp\` (was 0 bytes, no content lost)

## Unblocks

\`apply-mcp-standard.py --repo ~/Projects/Austrian-law-mcp\` will now proceed past the dirty-tree check and apply the full golden-standard treatment (Vercel removal, npm-publish workflow removal, ingestion-script removal for \`node-wasm-curated\` profile, Dockerfile rewrite to x-mcp-defaults).

## Why the .tmp was tracked in the first place

Best guess: an early commit accidentally included it via \`git add -A\` or \`git add data/\` before the gitignore was complete. It's been silently around since then. download-db.sh's \`gunzip -c \"$tmp_gz\" > \"\${OUTPUT}.tmp\"\` line writes content here, then renames to the final path. So pretest runs effectively deleted the tracked file every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)