### PR TITLE
fix(lint-dockerfile): only check runtime dependencies for native deps

### DIFF
--- a/.github/scripts/lint-dockerfile.py
+++ b/.github/scripts/lint-dockerfile.py
@@ -37,11 +37,17 @@ _NATIVE_DEPS: tuple[str, ...] = ("better-sqlite3",)
 
 
 def _detect_native_dep(repo_root: Path) -> str:
-    """Return the native dep name found in package.json, or '' if none.
+    """Return the native dep name found in runtime `dependencies`, or '' if none.
 
-    Walks both `dependencies` and `devDependencies`. A repo without a
-    package.json sibling to the Dockerfile is treated as non-Node and
-    the gate skips.
+    Checks ONLY `dependencies` (runtime), not `devDependencies`. A native dep
+    that appears only in devDependencies is build-time only and is excluded
+    from the runtime image by `npm ci --omit=dev` — it doesn't need to be
+    rebuilt/copied to the runtime stage. Common case: MCPs that ship a
+    pre-built DB and use `better-sqlite3` only in `scripts/build-db.ts` for
+    local dev seed builds.
+
+    A repo without a package.json sibling to the Dockerfile is treated as
+    non-Node and the gate skips.
     """
     pkg_path = repo_root / "package.json"
     if not pkg_path.is_file():
@@ -50,10 +56,7 @@ def _detect_native_dep(repo_root: Path) -> str:
         manifest = json.loads(pkg_path.read_text())
     except (json.JSONDecodeError, OSError):
         return ""
-    deps = {
-        **(manifest.get("dependencies") or {}),
-        **(manifest.get("devDependencies") or {}),
-    }
+    deps = manifest.get("dependencies") or {}
     for name in _NATIVE_DEPS:
         if name in deps:
             return name


### PR DESCRIPTION
## Summary

Phase B Dockerfile lint was flagging this repo's \`npm ci --omit=dev --ignore-scripts\` runtime stage as a regression because \`better-sqlite3\` appears in \`devDependencies\`. But better-sqlite3 is **build-time only** here (used by \`scripts/build-db.ts\` for local-dev seed builds); the runtime uses \`@ansvar/mcp-sqlite\` (pure WASM, no native binding).

The runtime image excludes devDependencies via \`--omit=dev\`, so the native binding never needs to be present — and \`--ignore-scripts\` is correct (no postinstall to skip).

## Fix

\`_detect_native_dep\` checks only \`dependencies\` (runtime), not \`devDependencies\`. If a native dep appears only in devDeps, the runtime image doesn't ship it.

## Verification

\`\`\`
$ python3 .github/scripts/lint-dockerfile.py Dockerfile
OK: Dockerfile passes Phase B Dockerfile lint
\`\`\`

## Unblocks

The post-treatment GHCR build that was failing on the audit/golden-standard-2026-05-16 merge.

## Fleet-wide follow-up

This is a fleet-wide template bug — the same lint script is copied to every MCP via \`apply-golden-standard.sh\` in arch-docs. The source at \`scripts/lint-mcp-dockerfile.py\` in Ansvar-Architecture-Documentation needs the same fix to prevent regression on future treatments. Tracking as a follow-up arch-docs PR after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)