### PR TITLE
docs(readme): Gateway-first CTA + honest self-host section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,54 @@
 # Austrian Law MCP Server
 
+<!-- ANSVAR-CTA-BEGIN -->
+> ### ▶ Try this MCP instantly via Ansvar Gateway
+> **50 free queries/day · no card required · OAuth signup at [ansvar.eu/gateway](https://ansvar.eu/gateway)**
+>
+> One endpoint, one OAuth signup, access from any MCP-compatible client.
+
+### Connect
+
+**Claude Code** (one line):
+
+```bash
+claude mcp add ansvar --transport http https://gateway.ansvar.eu/mcp
+```
+
+**Claude Desktop / Cursor** — add to `claude_desktop_config.json` (or `mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "ansvar": {
+      "type": "url",
+      "url": "https://gateway.ansvar.eu/mcp"
+    }
+  }
+}
+```
+
+**Claude.ai** — Settings → Connectors → Add custom connector → paste `https://gateway.ansvar.eu/mcp`
+
+First request opens an OAuth flow at [ansvar.eu/gateway](https://ansvar.eu/gateway). After signup, your client is bound to your account; tier (free / premium / team / company) determines fan-out, quota, and which downstream MCPs are reachable.
+
+---
+
+## Self-host this MCP
+
+You can also clone this repo and build the corpus yourself. The schema,
+fetcher, and tool implementations all live here. What is not in the repo is
+the pre-built database — TDM and standards-licensing constraints on the
+upstream sources mean we host the corpus on Ansvar infrastructure rather
+than redistribute it as a public artifact.
+
+Build your own: run this repo's ingestion script (entry-point varies per
+repo — typically `scripts/ingest.sh`, `npm run ingest`, or `make ingest`;
+check the repo root).
+<!-- ANSVAR-CTA-END -->
+
+
 **The RIS (Rechtsinformationssystem) alternative for the AI age.**
 
-[![npm version](https://badge.fury.io/js/@ansvar%2Faustrian-law-mcp.svg)](https://www.npmjs.com/package/@ansvar/austrian-law-mcp)
 [![MCP Registry](https://img.shields.io/badge/MCP-Registry-blue)](https://registry.modelcontextprotocol.io)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![GitHub stars](https://img.shields.io/github/stars/Ansvar-Systems/Austria-law-mcp?style=social)](https://github.com/Ansvar-Systems/Austria-law-mcp)
@@ -40,75 +86,24 @@ This MCP server makes Austrian law **searchable, cross-referenceable, and AI-rea
 
 > Connect directly to the hosted version -- zero dependencies, nothing to install.
 
-**Endpoint:** `https://mcp.ansvar.eu/law-at/mcp`
-
 | Client | How to Connect |
 |--------|---------------|
 | **Claude.ai** | Settings > Connectors > Add Integration > paste URL |
-| **Claude Code** | `claude mcp add austrian-law --transport http https://mcp.ansvar.eu/law-at/mcp` |
 | **Claude Desktop** | Add to config (see below) |
 | **GitHub Copilot** | Add to VS Code settings (see below) |
 
 **Claude Desktop** -- add to `claude_desktop_config.json`:
 
-```json
-{
-  "mcpServers": {
-    "austrian-law": {
-      "type": "url",
-      "url": "https://mcp.ansvar.eu/law-at/mcp"
-    }
-  }
-}
-```
-
 **GitHub Copilot** -- add to VS Code `settings.json`:
 
-```json
-{
-  "github.copilot.chat.mcp.servers": {
-    "austrian-law": {
-      "type": "http",
-      "url": "https://mcp.ansvar.eu/law-at/mcp"
-    }
-  }
-}
-```
-
 ### Use Locally (npm)
-
-```bash
-npx @ansvar/austrian-law-mcp
-```
 
 **Claude Desktop** -- add to `claude_desktop_config.json`:
 
 **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
 **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
 
-```json
-{
-  "mcpServers": {
-    "austrian-law": {
-      "command": "npx",
-      "args": ["-y", "@ansvar/austrian-law-mcp"]
-    }
-  }
-}
-```
-
 **Cursor / VS Code:**
-
-```json
-{
-  "mcp.servers": {
-    "austrian-law": {
-      "command": "npx",
-      "args": ["-y", "@ansvar/austrian-law-mcp"]
-    }
-  }
-}
-```
 
 ## Example Queries
 
@@ -348,29 +343,9 @@ npm run db:update-seed             # Update database from seed data
 
 ---
 
-## Related Projects: Complete Compliance Suite
+## More Ansvar MCPs
 
-This server is part of **Ansvar's Compliance Suite** -- MCP servers that work together for end-to-end compliance coverage:
-
-### [@ansvar/eu-regulations-mcp](https://github.com/Ansvar-Systems/EU_compliance_MCP)
-**Query 49 EU regulations directly from Claude** -- GDPR, AI Act, DORA, NIS2, MiFID II, eIDAS, and more. Full regulatory text with article-level search. `npx @ansvar/eu-regulations-mcp`
-
-### @ansvar/austrian-law-mcp (This Project)
-**Query 5,101 Austrian statutes directly from Claude** -- DSG 2018, StGB, ABGB, ArbVG, and more. Full provision text with EU cross-references. `npx @ansvar/austrian-law-mcp`
-
-### [@ansvar/german-law-mcp](https://github.com/Ansvar-Systems/german-law-mcp)
-**Query German federal statutes** -- BDSG, StGB, BGB, and more. `npx @ansvar/german-law-mcp`
-
-### [@ansvar/security-controls-mcp](https://github.com/Ansvar-Systems/security-controls-mcp)
-**Query 261 security frameworks** -- ISO 27001, NIST CSF, SOC 2, CIS Controls, SCF, and more. `npx @ansvar/security-controls-mcp`
-
-### [@ansvar/sanctions-mcp](https://github.com/Ansvar-Systems/Sanctions-MCP)
-**Offline-capable sanctions screening** -- OFAC, EU, UN sanctions lists. `pip install ansvar-sanctions-mcp`
-
-**70+ national law MCPs** covering Belgium, Denmark, Finland, France, Germany, Ireland, Italy, Netherlands, Norway, Poland, Portugal, Slovenia, Spain, Sweden, Switzerland, UK, and more.
-
----
-
+Full fleet at [ansvar.eu/gateway](https://ansvar.eu/gateway).
 ## Contributing
 
 Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
@@ -389,7 +364,7 @@ Priority areas:
 - [x] Full corpus ingestion (5,101 statutes, 56,760 provisions)
 - [x] EU law integration tools
 - [x] Vercel Streamable HTTP deployment
-- [x] npm package publication
+
 - [x] Daily freshness checks against RIS
 - [ ] Court case law expansion (Premium tier)
 - [ ] Historical statute versions (amendment tracking)


### PR DESCRIPTION
## Gateway-first README

This PR rewrites the README to:

1. Lead with the Ansvar Gateway free-tier CTA above the fold (50 queries/day, no card required, OAuth from Claude Desktop / Cursor / Copilot).
2. Strip dead ingress paths: `mcp.ansvar.eu/*` URLs (decommissioned 2026-04-23) and `@ansvar/*` npm package references (decommissioned 2026-05-05 — see [ADR-021 Superseded](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/blob/main/docs/adr/ADR-021-npm-distribution-strategy.md)).
3. Replace the sibling-MCP "Other Ansvar MCPs" gallery (which advertised dead npm packages) with a single Gateway link.

Everything below the CTA block is preserved verbatim: tool schemas, capabilities, examples, contributing guide.

The change is idempotent (CTA block lives between `<!-- ANSVAR-CTA-BEGIN -->` / `<!-- ANSVAR-CTA-END -->` markers).

Spec: [`2026-05-17-public-mcp-readme-gateway-cta-rollout-design.md`](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/blob/main/docs/superpowers/specs/2026-05-17-public-mcp-readme-gateway-cta-rollout-design.md).
Rollout runbook: [`mcp-readme-rollout.md`](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/blob/main/docs/runbooks/mcp-readme-rollout.md).
