### PR TITLE
chore: sync license to AT-Statutory-PD per arch-docs 2026-05-17

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ All content is sourced from authoritative Austrian legal databases:
 | **Authority** | Bundeskanzleramt Österreich |
 | **Retrieval method** | RIS OGD API |
 | **Language** | German |
-| **License** | RIS data (public domain, Austria) |
+| **License** | `AT-Statutory-PD` — Austrian statutory public domain (UrhG §7(1) "Freie Werke") |
 | **Coverage** | 5,101 federal statutes |
 | **Last ingested** | 2026-02-25 |
 
@@ -370,8 +370,8 @@ Apache License 2.0. See [LICENSE](./LICENSE) for details.
 
 ### Data Licenses
 
-- **Statutes & Legislation:** Bundeskanzleramt Österreich (public domain, RIS OGD)
-- **EU Metadata:** EUR-Lex (EU public domain)
+- **Statutes & Legislation:** `AT-Statutory-PD` — Austrian statutory public domain. UrhG §7(1) "Freie Werke" excludes laws (`Gesetze`), ordinances (`Verordnungen`), official decrees (`amtliche Erlässe`), public notices (`Bekanntmachungen`), and court decisions (`Entscheidungen`) from copyright protection. Verified verbatim 2026-05-17 via RIS consolidated text — see [`docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1a-AT-BE-DK-FI-FR.md`](https://github.com/Ansvar-Systems/Ansvar-Architecture-Documentation/blob/main/docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1a-AT-BE-DK-FI-FR.md) in arch-docs. Catalog entry: `AT-Statutory-PD` in `infrastructure/attribution-licenses.json`.
+- **EU Metadata:** EUR-Lex (EU public domain, Decision 2011/833/EU)
 
 ---
 

--- a/sources.yml
+++ b/sources.yml
@@ -1,3 +1,11 @@
+# sources.yml — Data provenance metadata
+# License axis: AT-Statutory-PD (Austrian statutory public domain)
+# Statutory basis: UrhG §7(1) "Freie Werke" — Gesetze, Verordnungen, amtliche
+# Erlässe, Bekanntmachungen, and Entscheidungen are excluded from copyright
+# protection. Verified verbatim 2026-05-17 via RIS consolidated text.
+# Cross-ref: docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1a-AT-BE-DK-FI-FR.md
+# Catalog entry: infrastructure/attribution-licenses.json → "AT-Statutory-PD"
+
 schema_version: '1.0'
 mcp_name: 'Austrian Law MCP'
 jurisdiction: 'AT'
@@ -12,9 +20,9 @@ sources:
     update_frequency: 'weekly'
     last_ingested: '2026-02-16'
     license_or_terms:
-      type: 'CC BY 4.0'
-      url: 'https://creativecommons.org/licenses/by/4.0/'
-      summary: 'Austrian government open data under Creative Commons Attribution 4.0'
+      type: 'AT-Statutory-PD'
+      url: 'https://www.ris.bka.gv.at/NormDokument.wxe?Abfrage=Bundesnormen&Gesetzesnummer=10001848&Paragraf=7'
+      summary: 'Austrian statutory public domain (UrhG §7(1) "Freie Werke"). Laws, ordinances, official decrees, public notices, and court decisions are excluded from copyright protection. Statute-level basis on the underlying text; RIS OGD portal additionally publishes structured data under CC BY 4.0 for the compilation.'
     coverage:
       scope: 'Austrian federal laws (cybersecurity and data protection scope)'
       limitations: 'Initial release covers key cybersecurity legislation only'


### PR DESCRIPTION
## Summary

Replace generic license declaration with the jurisdiction-specific statutory-PD code that landed in arch-docs catalog today.

- `sources.yml` license type: `CC BY 4.0` → `AT-Statutory-PD`
- README data-provenance + data-licenses block point at UrhG §7(1) "Freie Werke" and the new catalog entry

## Statutory basis

UrhG §7(1) excludes from copyright protection: laws (`Gesetze`), ordinances (`Verordnungen`), official decrees (`amtliche Erlässe`), public notices (`Bekanntmachungen`), and court decisions (`Entscheidungen`). Verified verbatim 2026-05-17 via RIS consolidated text.

## Scope

License-axis sync only. No corpus content, ingestion code, or runtime behaviour changes.

## Cross-references

- `docs/audits/2026-05-17-eu-copyright-statutory-works-batch-1a-AT-BE-DK-FI-FR.md` (arch-docs)
- `infrastructure/attribution-licenses.json` → `AT-Statutory-PD` (arch-docs)

## Test plan

- [ ] CI green (7 workflows + tests)
- [ ] No diff in `data/` or `src/` (license-axis only)